### PR TITLE
Import custom Status by label as well as id

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,15 @@ terraform {
   required_providers {
     zendesk = {
       source  = "andsafe-AG/zendesk"
-      version = ">= 0.0.1"
+      version = ">= 1.0.0"
     }
   }
+}
+
+provider "zendesk" {
+  account = "my-zendesk-subdomain"
+  email   = "zendesk-user@email.com"
+  token   = "my-api-token"
 }
 ```
 

--- a/examples/resources/custom_status/import.sh
+++ b/examples/resources/custom_status/import.sh
@@ -1,2 +1,4 @@
 # Custom Ticket Status can be imported by specifying the numeric identifier.
 terraform import zendesk_custom_status.example 123
+# It can also be imported by specifying the agent label.
+terraform import zendesk_custom_status.example my-agent-label-for-custom-status

--- a/examples/resources/custom_status/resource.tf
+++ b/examples/resources/custom_status/resource.tf
@@ -8,13 +8,13 @@ resource "zendesk_custom_status" "example_status" {
   custom_status = {
     # Choose one of the categories: new, open, pending, hold, or solved
     status_category = "open"
-    # Label that will be displayed to agents in the UI. Must be unique.
+    # Label that will be displayed to agents in the UI. Must be unique, max. 48 characters
     agent_label = "In Progress"
-    # Label that will be displayed to end users in the UI
+    # Label that will be displayed to end users in the UI, max. 48 characters
     end_user_label = "We are on it!"
-    # Description of the status for agents, max. 48 characters
+    # Description of the status for agents
     description = "This is an example progress status"
-    # Description of the status for end users, max.48 characters
+    # Description of the status for end users
     end_user_description = "Your request is being processed."
     # Whether the status is active or not. Not active would mean that the status is not available for selection in the UI
     active = true

--- a/internal/provider/custom_ticket_status_resource_test.go
+++ b/internal/provider/custom_ticket_status_resource_test.go
@@ -56,14 +56,16 @@ func TestAccCustomStatusResource(t *testing.T) {
 			},
 			// ImportState testing
 			{
+				Config:                               providerConfig + testAccCustomStatusResourceConfig("two"),
 				ResourceName:                         "zendesk_custom_status.test",
 				ImportState:                          true,
+				ImportStateId:                        "two",
 				ImportStateVerifyIdentifierAttribute: "custom_status_id",
-				// This is not normally necessary, but is here because this
-				// example code does not have an actual upstream service.
-				// Once the Read method is able to refresh information from
-				// the upstream service, this can be removed.
-				ImportStateVerifyIgnore: []string{"agent_label"},
+				ImportStateVerifyIgnore:              []string{"agent_label"},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"zendesk_custom_status.test", "custom_status.agent_label", "two"),
+				),
 			},
 			// Update and Read testing
 			{

--- a/zendesk_api/mock/config/list_response.json
+++ b/zendesk_api/mock/config/list_response.json
@@ -1,0 +1,36 @@
+{
+  "custom_statuses": [
+    {
+      "active": true,
+      "id": 19682857720989,
+      "agent_label": "one",
+      "description": "test descr",
+      "end_user_description": "test end user descr",
+      "end_user_label": "one",
+      "status_category": "open",
+      "created_at": "2021-06-02T14:00:00Z",
+      "updated_at": "2021-06-02T14:00:00Z",
+      "default": false,
+      "raw_agent_label": "one",
+      "raw_end_user_label": "test end user label",
+      "raw_description": "test descr",
+      "raw_end_user_description": "test end user descr"
+    },
+    {
+      "active": true,
+      "id": 19691825497501,
+      "agent_label": "two",
+      "description": "test descr 2",
+      "end_user_description": "test end user descr 2",
+      "end_user_label": "two",
+      "status_category": "open",
+      "created_at": "2021-06-02T14:00:00Z",
+      "updated_at": "2021-06-02T14:00:00Z",
+      "default": false,
+      "raw_agent_label": "two",
+      "raw_end_user_label": "test end user label 2",
+      "raw_description": "test descr 2",
+      "raw_end_user_description": "test end user descr 2"
+    }
+  ]
+}

--- a/zendesk_api/mock/config/zendesk-config.yaml
+++ b/zendesk_api/mock/config/zendesk-config.yaml
@@ -2,6 +2,11 @@ plugin: openapi
 specFile: zendesk-support-api.yaml
 resources:
   - path: "/api/v2/custom_statuses"
+    method: GET
+    response:
+      file: list_response.json
+      statusCode: 200
+  - path: "/api/v2/custom_statuses"
     method: POST
     requestBody:
       jsonPath: $.custom_status.agent_label


### PR DESCRIPTION
An existing Custom Status can be imported to the Terraform State by specifying agent_label, or by id.

Since the id can only be fetched by using the REST API, it is important to allow import by specifying the agent_label, which is visible to every user of the Zendesk instance.